### PR TITLE
Use rioxarray's reproject_match instead of invoking gdalwarp

### DIFF
--- a/01_wildfire_ML/Hazard_assessment_FIRE_ML.ipynb
+++ b/01_wildfire_ML/Hazard_assessment_FIRE_ML.ipynb
@@ -94,6 +94,7 @@
     "import rasterio\n",
     "import rasterio.plot\n",
     "from rasterio.mask import mask\n",
+    "import rioxarray as rxr\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.colors as mcolors\n",
@@ -336,14 +337,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with rasterio.open(dem_path_clip) as src:\n",
-    "    ref = src.read(1)\n",
-    "    # Boundaries\n",
-    "    left = src.bounds.left\n",
-    "    bottom = src.bounds.bottom\n",
-    "    right = src.bounds.right\n",
-    "    top = src.bounds.top\n",
-    "    print(src.bounds)"
+    "ds_dem = rxr.open_rasterio(dem_path_clip)\n",
+    "\n",
+    "# Reference array from raster values\n",
+    "ref = ds_dem.sel({\"band\": 1}).values\n",
+    "\n",
+    "def reproject_match_reference(path_in, path_out):\n",
+    "    # Read the input file, reproject to match resolution, projection, and region then write\n",
+    "    return (\n",
+    "        rxr.open_rasterio(path_in)\n",
+    "        .rio.reproject_match(ds_dem, resampling=rasterio.enums.Resampling.bilinear)\n",
+    "        .rio.to_raster(path_out, COMPRESS=\"LZW\", TILED=\"YES\", BIGTIFF=\"YES\", BLOCKXSIZE=512, BLOCKYSIZE=512)\n",
+    "    )"
    ]
   },
   {
@@ -744,8 +749,8 @@
     "        # Construct the output path by joining the output folder, the subfolder and the filename\n",
     "        output_path = os.path.join(output_subfolder, filename)\n",
     "        output_paths.append(output_path)\n",
-    "        # Perform gdalwarp using the string command. I use the data of the blueprint DEM raster as a reference\n",
-    "        os.system(f\"gdalwarp -t_srs EPSG:3035 -tr 100 -100 -te {left} {bottom} {right} {top} -r bilinear  -overwrite -co COMPRESS=LZW -co TILED=YES -co BIGTIFF=YES -co BLOCKXSIZE=512 -co BLOCKYSIZE=512 {raster_path} {output_path}\")\n",
+    "        # Use the data of the blueprint DEM raster as a reference for reprojection\n",
+    "        reproject_match_reference(raster_path, output_path)\n",
     "    return output_paths\n",
     "\n",
     "\n",
@@ -842,7 +847,7 @@
     }
    ],
    "source": [
-    "os.system(f\"gdalwarp -t_srs EPSG:3035 -tr 100 -100 -te {left} {bottom} {right} {top} -r near  -overwrite -co COMPRESS=LZW -co TILED=YES -co BIGTIFF=YES -co BLOCKXSIZE=512 -co BLOCKYSIZE=512 {clc_path_full} {clc_path_clip}\")"
+    "reproject_match_reference(clc_path_full, clc_path_clip)"
    ]
   },
   {


### PR DESCRIPTION
- [x] ECLIPS notebook
- [ ] CHELSA notebook (also replace direct calls to gdal package)

Closes #11.